### PR TITLE
Fix: Update presentation duration from 45 to 30 minutes

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
                 </div>
                 <div class="info-item">
                     <div class="info-label">Duration</div>
-                    <div class="info-value">45 minutes</div>
+                    <div class="info-value">30 minutes</div>
                 </div>
                 <div class="info-item">
                     <div class="info-label">Level</div>


### PR DESCRIPTION
## 🎯 Purpose
This PR fixes the presentation duration displayed on the landing page, changing it from 45 minutes to 30 minutes as requested.

## 📝 Changes
- Updated the duration value in the "Presentation Overview" section from "45 minutes" to "30 minutes"
- No layout or styling changes required - this is a simple content update

## 🔗 Related Issue
Fixes #1 

## ✅ Checklist
- [x] Updated duration value from "45 minutes" to "30 minutes"
- [x] Tested that the change displays correctly
- [x] Layout remains consistent after the change
- [x] No other functionality affected

## 🖼️ Before & After
**Before:** Duration: 45 minutes  
**After:** Duration: 30 minutes

## 🧪 Testing
- [x] Verified the HTML renders correctly
- [x] Confirmed responsive layout still works
- [x] No console errors or visual issues

Ready for review and merge! 🚀